### PR TITLE
Fix error in chrome with undefined tab.id

### DIFF
--- a/public/background.js
+++ b/public/background.js
@@ -20,7 +20,7 @@ chrome.runtime.onConnect.addListener(port => {
   }
 
   let extensionListener = message => {
-    const tabId = port.sender?.tab.id >= 0 ? port.sender.tab.id : message.tabId;
+    const tabId = port.sender?.tab?.id >= 0 ? port.sender.tab.id : message.tabId;
 
     // The original connection event doesn't include the tab ID of the
     // DevTools page, so we need to send it explicitly (attached


### PR DESCRIPTION
Hey, I was setting up this fork in my project and noticed an error in chrome out of the box.  Looks like `port.sender.tab` was `undefined` causing the conditional of the ternary operator to throw an error.  This one-liner should stop that from happening.  I've built and my team is using this version locally.

I'm on OSX Big Sur on Chrome 88.0.4324.192



![Screen Shot 2021-02-26 at 12 14 06 PM](https://user-images.githubusercontent.com/896170/109351139-9397e980-782d-11eb-986a-211591d8a75c.png)
